### PR TITLE
modified versions to work with bioconda packages

### DIFF
--- a/versions.py
+++ b/versions.py
@@ -4,7 +4,7 @@
 import Bio
 import argparse
 import getpass
-import logging as log
+import logging
 import os
 from subprocess import Popen, PIPE, check_call
 import sys
@@ -99,16 +99,15 @@ def _parse_args():
 def _check_package(pkg_name):
     command = ['which', pkg_name]
 
-    log.info('Executing: %s', ' '.join(command))
+    logging.info('Executing: %s', ' '.join(command))
     check_call(command, stdout=None)
 
 def main():
     """Method intended to be run when __name-- == '__main__'."""
     # BioPython
-    log.info('BioPython\t%s', Bio.__version__)
+    logging.info('BioPython\t%s', Bio.__version__)
 
     # Blast
-    print(MAKEBLASTDB)
     _check_package(MAKEBLASTDB)
     _check_package(BLASTP)
     _check_package(BLASTN)
@@ -146,6 +145,6 @@ def main():
 
 if __name__ == '__main__':
     # Parse arguments to setup logging; not in main for testing
-    #_parse_args()
+    _parse_args()
     # Log software versions
     main()

--- a/versions.py
+++ b/versions.py
@@ -4,9 +4,9 @@
 import Bio
 import argparse
 import getpass
-import logging
+import logging as log
 import os
-from subprocess import Popen, PIPE
+from subprocess import Popen, PIPE, check_call
 import sys
 
 
@@ -15,58 +15,54 @@ __copyright__ = "Copyright 2011, Netherlands Bioinformatics Centre"
 __license__ = "MIT"
 
 
-SOFTWARE_DIR = '/work/odosenl/software/'
-if getpass.getuser() == 'tim':
-    SOFTWARE_DIR = '/home/tim/Documents/dev/odosenl/software/'
+SOFTWARE_DIR = os.path.dirname(os.path.abspath(__file__)) + '/'
 if not os.path.isdir(SOFTWARE_DIR):
     logging.error('Software directory is missing: %s', SOFTWARE_DIR)
 
 # Blast
-NCBI_BLAST_DIR = SOFTWARE_DIR + 'ncbi-blast-2.2.30+/bin/'
 # ftp://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/LATEST
-MAKEBLASTDB = NCBI_BLAST_DIR + 'makeblastdb'
-BLASTP = NCBI_BLAST_DIR + 'blastp'
-BLASTN = NCBI_BLAST_DIR + 'blastn'
+MAKEBLASTDB = SOFTWARE_DIR + 'makeblastdb'
+BLASTP = SOFTWARE_DIR + 'blastp'
+BLASTN = SOFTWARE_DIR + 'blastn'
 
 # Life Science Grid Portal
 # https://apps.grid.sara.nl/applications/makeblastdb/
-LSGP_MAKEBLASTDB = 'makeblastdb/2.2.26'
-LSGP_BLASTN = 'blastn/2.2.26'
-LSGP_BLASTP = 'blastp/2.2.27'
+LSGP_MAKEBLASTDB = SOFTWARE_DIR + 'makeblastdb/2.2.26'
+LSGP_BLASTN = SOFTWARE_DIR + 'blastn/2.2.26'
+LSGP_BLASTP = SOFTWARE_DIR + 'blastp/2.2.27'
 
 # OrthoMCL
 # http://www.orthomcl.org/common/downloads/software/v2.0/
-ORTHOMCL_DIR = SOFTWARE_DIR + 'orthomclSoftware-v2.0.9/bin/'
-ORTHOMCL_INSTALL_SCHEMA = ORTHOMCL_DIR + 'orthomclInstallSchema'
-ORTHOMCL_ADJUST_FASTA = ORTHOMCL_DIR + 'orthomclAdjustFasta'
-ORTHOMCL_FILTER_FASTA = ORTHOMCL_DIR + 'orthomclFilterFasta'
-ORTHOMCL_BLAST_PARSER = ORTHOMCL_DIR + 'orthomclBlastParser'
-ORTHOMCL_LOAD_BLAST = ORTHOMCL_DIR + 'orthomclLoadBlast'
-ORTHOMCL_PAIRS = ORTHOMCL_DIR + 'orthomclPairs'
-ORTHOMCL_DUMP_PAIRS_FILES = ORTHOMCL_DIR + 'orthomclDumpPairsFiles'
-ORTHOMCL_MCL_TO_GROUPS = ORTHOMCL_DIR + 'orthomclMclToGroups'
+ORTHOMCL_INSTALL_SCHEMA = SOFTWARE_DIR + 'orthomclInstallSchema'
+ORTHOMCL_ADJUST_FASTA = SOFTWARE_DIR + 'orthomclAdjustFasta'
+ORTHOMCL_FILTER_FASTA = SOFTWARE_DIR + 'orthomclFilterFasta'
+ORTHOMCL_BLAST_PARSER = SOFTWARE_DIR + 'orthomclBlastParser'
+ORTHOMCL_LOAD_BLAST = SOFTWARE_DIR + 'orthomclLoadBlast'
+ORTHOMCL_PAIRS = SOFTWARE_DIR + 'orthomclPairs'
+ORTHOMCL_DUMP_PAIRS_FILES = SOFTWARE_DIR + 'orthomclDumpPairsFiles'
+ORTHOMCL_MCL_TO_GROUPS = SOFTWARE_DIR + 'orthomclMclToGroups'
 # http://micans.org/mcl/
-MCL = SOFTWARE_DIR + 'mcl-12-135/src/shmcl/mcl'
+MCL = SOFTWARE_DIR + 'mcl'
 
 # Align & Trim
 # http://pc16141.mncn.csic.es/cgi-bin/translatorx_vLocal.pl
-TRANSLATORX = SOFTWARE_DIR + 'translatorx/translatorx_v1.1.pl'
+TRANSLATORX = SOFTWARE_DIR + 'translatorx'
 
 # Concatemer tree
 # http://evolution.genetics.washington.edu/phylip.html
-PHYLIP_DIR = SOFTWARE_DIR + 'phylip-3.69/'
-DNADIST = PHYLIP_DIR + 'exe/dnadist'
-NEIGHBOR = PHYLIP_DIR + 'exe/neighbor'
+PHYLIP = SOFTWARE_DIR + 'phylip'
+DNADIST = PHYLIP + ' ' + 'dnadist'
+NEIGHBOR = PHYLIP + ' ' + 'neighbor'
 
 # Recombination
 # http://www.maths.otago.ac.nz/~dbryant/software.html
-PHIPACK = SOFTWARE_DIR + 'PhiPack/Phi'
+PHIPACK = SOFTWARE_DIR + 'Phi'
 
 # Calculation
 # http://abacus.gene.ucl.ac.uk/software/paml.html
-PAML_DIR = SOFTWARE_DIR + 'paml4.7/'
-CODEML = PAML_DIR + 'bin/codeml'
-
+#PAML_DIR = SOFTWARE_DIR + 'paml4.7/'
+#CODEML = PAML_DIR + 'bin/codeml'
+CODEML = SOFTWARE_DIR + 'codeml'
 
 def _call_program(*command):
     """Execute command and return the standard output returned by the program. Standard error is caught and ignored."""
@@ -100,39 +96,56 @@ def _parse_args():
     # Return any other args
     return args
 
+def _check_package(pkg_name):
+    command = ['which', pkg_name]
+
+    log.info('Executing: %s', ' '.join(command))
+    check_call(command, stdout=None)
 
 def main():
     """Method intended to be run when __name-- == '__main__'."""
     # BioPython
-    logging.info('BioPython\t%s', Bio.__version__)
+    log.info('BioPython\t%s', Bio.__version__)
 
     # Blast
-    logging.info('makeblastdb\t%s', _call_program(MAKEBLASTDB, '-version').split('\n')[1])
-    logging.info('blastp\t%s', _call_program(BLASTP, '-version').split('\n')[1])
-    logging.info('blastn\t%s', _call_program(BLASTN, '-version').split('\n')[1])
+    print(MAKEBLASTDB)
+    _check_package(MAKEBLASTDB)
+    _check_package(BLASTP)
+    _check_package(BLASTN)
 
     # Life Science Grid Portal
-    logging.info('LSGP %s', LSGP_MAKEBLASTDB.replace('/', '\t'))
-    logging.info('LSGP %s', LSGP_BLASTP.replace('/', '\t'))
-    logging.info('LSGP %s', LSGP_BLASTN.replace('/', '\t'))
+    #logging.info('LSGP %s', LSGP_MAKEBLASTDB.replace('/', '\t'))
+    #logging.info('LSGP %s', LSGP_BLASTP.replace('/', '\t'))
+    #logging.info('LSGP %s', LSGP_BLASTN.replace('/', '\t'))
 
     # OrthoMCL & mcl
-    logging.info('OrthoMCL\t%s', _grep_version(ORTHOMCL_DIR + '../doc/OrthoMCLEngine/Main/releaseNotes.txt', pattern='v2'))
-    logging.info('MCL\t%s', _call_program(MCL, '--version').split('\n')[0])
-
-    # PAML codeml
-    logging.info('PAML codeml\t%s', _grep_version(PAML_DIR + 'src/paml.h'))
-
-    # PHYLIP dnadist & neighbor
-    logging.info('PHYLIP dnadist\t%s', _grep_version(PHYLIP_DIR + 'src/dnadist.c')[3:])
-    logging.info('PHYLIP neighbor\t%s', _grep_version(PHYLIP_DIR + 'src/neighbor.c')[3:])
+    _check_package(ORTHOMCL_INSTALL_SCHEMA)
+    _check_package(ORTHOMCL_ADJUST_FASTA)
+    _check_package(ORTHOMCL_FILTER_FASTA)
+    _check_package(ORTHOMCL_BLAST_PARSER)
+    _check_package(ORTHOMCL_LOAD_BLAST)
+    _check_package(ORTHOMCL_PAIRS)
+    _check_package(ORTHOMCL_DUMP_PAIRS_FILES)
+    _check_package(ORTHOMCL_MCL_TO_GROUPS)
+    _check_package(MCL)
 
     # TranslatorX calls muscle internally
-    logging.info('translatorx\t%s', _grep_version(TRANSLATORX, pattern='TranslatorX v')[28:-6])
-    logging.info('Muscle\t%s', _call_program('muscle', '-version'))
+    _check_package(TRANSLATORX)
+    #logging.info('Muscle\t%s', _call_program('muscle', '-version'))
+
+    # PHYLIP dnadist & neighbor
+    _check_package(PHYLIP)
+    _check_package(DNADIST)
+    _check_package(NEIGHBOR)
+
+    # PHIPACK
+    _check_package(PHIPACK)
+
+    # PAML codeml
+    _check_package(CODEML)
 
 if __name__ == '__main__':
     # Parse arguments to setup logging; not in main for testing
-    _parse_args()
+    #_parse_args()
     # Log software versions
     main()


### PR DESCRIPTION
Hi @timtebeek,

This modification allows ODoSE to point to the bioconda packages of the needed dependencies (which will be installed automatically when the user installs ODoSE through bioconda, which is the case with Galaxy).
Currently, not all packages are on bioconda, but all have currently PRs to be on bioconda within the next 2 days.
I used `which` to verify the locations of the needed packages because not all packages can output their version numbers. If you prefer t go with another idea, please let me know, and I will modify it accordingly.

Best regards,
Hassan Amr